### PR TITLE
fix weights unsqueeze in PixelWiseCrossEntropy

### DIFF
--- a/pytorch3dunet/unet3d/losses.py
+++ b/pytorch3dunet/unet3d/losses.py
@@ -216,7 +216,7 @@ class PixelWiseCrossEntropyLoss(nn.Module):
         # standard CrossEntropyLoss requires the target to be (NxDxHxW), so we need to expand it to (NxCxDxHxW)
         target = expand_as_one_hot(target, C=input.size()[1], ignore_index=self.ignore_index)
         # expand weights
-        weights = weights.unsqueeze(0)
+        weights = weights.unsqueeze(1)
         weights = weights.expand_as(input)
 
         # create default class_weights if None


### PR DESCRIPTION
First off, thanks for the great library, @wolny ! It has really accelerated my work being able to start with a nice implementation of 3D unets.

I think there might be a small bug in the `PixelWiseCrossEntropy` loss. It seems that the weights get passed in as a NxDxHxW tensor and in the "expand weights" code block they should be expanded to NxCxDxHxW tensor to match the `target` (which has been converted to a one hot encoding). Thus, I think the unsqueeze should be applied to axis 1, not axis 0. In this case the weights would become Nx1xDxHxW, then NxCxDxHxW in the subsequent `weights.expand_as(input)`.

Without this change, I get the following error when I train with batch size > 1.
```python 
2021-03-12 17:05:50,156 [MainThread] INFO UNet3DTrainer - Training iteration [1/100000]. Epoch [0/99]
Traceback (most recent call last):
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/train.py", line 33, in <module>
    main()
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/train.py", line 29, in main
    trainer.fit()
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/unet3d/trainer.py", line 246, in fit
    should_terminate = self.train()
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/unet3d/trainer.py", line 273, in train
    output, loss = self._forward_pass(input, target, weight)
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/unet3d/trainer.py", line 408, in _forward_pass
    loss = self.loss_criterion(output, target, weight)
  File "/cluster/apps/nss/gcc-6.3.0/python_gpu/3.8.5/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/cluster/home/kyamauch/.local/lib/python3.8/site-packages/pytorch3dunet/unet3d/losses.py", line 220, in forward
    weights = weights.expand_as(input)
RuntimeError: The expanded size of the tensor (3) must match the existing size (12) at non-singleton dimension 1.  Target sizes: [12, 3, 70, 70, 70].  Tensor sizes: [1, 12, 70, 70, 70]
```

Does this change seem right?