### PR TITLE
Create command-lines (i.e. console_scripts) when installing from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,9 @@ setup(
     author="Adrian Wolny, Lorenzo Cerrone",
     url="https://github.com/wolny/pytorch-3dunet",
     license="MIT",
-    python_requires='>=3.7'
+    python_requires='>=3.7', 
+    entry_points={'console_scripts': [
+        'train3dunet=pytorch3dunet.train:main',
+        'predict3dunet=pytorch3dunet.predict:main']
+        }
 )


### PR DESCRIPTION
Hi, 

I know that the command lines are installed into the conda environment.

This code adds commands when installing from source (i.e. python setup.py install). 
I needed to do this as I ultimately want to call pytorch-3dunet within mpi2/LAMA and don't want to use the conda env due to install issues etc.

Feel free to merge if it doesn't cause conflicts.

Kind Regards,
Kyle Drover