### PR TITLE
fix deprecated import of Sequence from collections

### DIFF
--- a/pytorch3dunet/datasets/utils.py
+++ b/pytorch3dunet/datasets/utils.py
@@ -277,7 +277,7 @@ def default_prediction_collate(batch):
         return torch.stack(batch, 0)
     elif isinstance(batch[0], tuple) and isinstance(batch[0][0], slice):
         return batch
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], collections.abc.Sequence):
         transposed = zip(*batch)
         return [default_prediction_collate(samples) for samples in transposed]
 


### PR DESCRIPTION
Hey from python 3.10 on  `collections.Sequence` will fail, I just change it with the current version `collections.abc.Sequence`