### PR TITLE
Fix AttributeError in Pillow package

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,3 +15,4 @@ dependencies:
   - scikit-image
   - pyyaml
   - pytest
+  - Pillow=9.5.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pyyaml
   - pytest
   - Pillow=9.5.0
+  - pandas


### PR DESCRIPTION
Creating a conda environment using the current environment.yaml file causes the error `AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'` during training. This is due to a new Pillow version (10.0.0.) released in July which removes the `ANTIALIAS` attribute (see [this release note](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants)). scikit-image automatically installs the latest Pillow package as a requirement. To avoid the error without changing much of the code, I specified the required Pillow package version.