### PR TITLE
implement optional conv_upscale parameter in AbstractUNet to allow to define at which convolution level upscaling should be performed.

### DIFF
--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -125,7 +125,7 @@ class DoubleConv(nn.Sequential):
             'ce' -> conv + ELU
         num_groups (int): number of groups for the GroupNorm
         padding (int or tuple): add zero-padding added to all three sides of the input
-        upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
+        upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
         is3d (bool): if True use Conv3d instead of Conv2d layers
     """
 
@@ -248,7 +248,7 @@ class Encoder(nn.Module):
             in `DoubleConv` module. See `DoubleConv` for more info.
         num_groups (int): number of groups for the GroupNorm
         padding (int or tuple): add zero-padding added to all three sides of the input
-        upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
+        upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
         is3d (bool): use 3d or 2d convolutions/pooling operation
     """
 
@@ -386,12 +386,12 @@ def create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_pa
     return nn.ModuleList(encoders)
 
 
-def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, conv_upscale, layer_order, num_groups, is3d):
+def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups, is3d):
     # create decoder path consisting of the Decoder modules. The length of the decoder list is equal to `len(f_maps) - 1`
     decoders = []
     reversed_f_maps = list(reversed(f_maps))
     for i in range(len(reversed_f_maps) - 1):
-        if basic_module == DoubleConv and conv_upscale is 2:
+        if basic_module == DoubleConv:
             in_feature_num = reversed_f_maps[i] + reversed_f_maps[i + 1]
         else:
             in_feature_num = reversed_f_maps[i]

--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -125,7 +125,7 @@ class DoubleConv(nn.Sequential):
             'ce' -> conv + ELU
         num_groups (int): number of groups for the GroupNorm
         padding (int or tuple): add zero-padding added to all three sides of the input
-        upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
+        upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
         is3d (bool): if True use Conv3d instead of Conv2d layers
     """
 
@@ -248,7 +248,7 @@ class Encoder(nn.Module):
             in `DoubleConv` module. See `DoubleConv` for more info.
         num_groups (int): number of groups for the GroupNorm
         padding (int or tuple): add zero-padding added to all three sides of the input
-        upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
+        upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
         is3d (bool): use 3d or 2d convolutions/pooling operation
     """
 
@@ -386,12 +386,12 @@ def create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_pa
     return nn.ModuleList(encoders)
 
 
-def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups, is3d):
+def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, conv_upscale, layer_order, num_groups, is3d):
     # create decoder path consisting of the Decoder modules. The length of the decoder list is equal to `len(f_maps) - 1`
     decoders = []
     reversed_f_maps = list(reversed(f_maps))
     for i in range(len(reversed_f_maps) - 1):
-        if basic_module == DoubleConv:
+        if basic_module == DoubleConv and conv_upscale is 2:
             in_feature_num = reversed_f_maps[i] + reversed_f_maps[i + 1]
         else:
             in_feature_num = reversed_f_maps[i]

--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -32,12 +32,13 @@ class AbstractUNet(nn.Module):
         conv_kernel_size (int or tuple): size of the convolving kernel in the basic_module
         pool_kernel_size (int or tuple): the size of the window
         conv_padding (int or tuple): add zero-padding added to all three sides of the input
+        conv_upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
         is3d (bool): if True the model is 3D, otherwise 2D, default: True
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid, basic_module, f_maps=64, layer_order='gcr',
                  num_groups=8, num_levels=4, is_segmentation=True, conv_kernel_size=3, pool_kernel_size=2,
-                 conv_padding=1, is3d=True):
+                 conv_padding=1, conv_upscale=2, is3d=True):
         super(AbstractUNet, self).__init__()
 
         if isinstance(f_maps, int):
@@ -49,8 +50,8 @@ class AbstractUNet(nn.Module):
             assert num_groups is not None, "num_groups must be specified if GroupNorm is used"
 
         # create encoder path
-        self.encoders = create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_padding, layer_order,
-                                        num_groups, pool_kernel_size, is3d)
+        self.encoders = create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_padding, conv_upscale,
+                                        layer_order, num_groups, pool_kernel_size, is3d)
 
         # create decoder path
         self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups,
@@ -110,7 +111,7 @@ class UNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, conv_upscale=2, **kwargs):
         super(UNet3D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -121,6 +122,7 @@ class UNet3D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     conv_upscale=conv_upscale,
                                      is3d=True)
 
 
@@ -133,7 +135,7 @@ class ResidualUNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, conv_upscale=2, **kwargs):
         super(ResidualUNet3D, self).__init__(in_channels=in_channels,
                                              out_channels=out_channels,
                                              final_sigmoid=final_sigmoid,
@@ -144,6 +146,7 @@ class ResidualUNet3D(AbstractUNet):
                                              num_levels=num_levels,
                                              is_segmentation=is_segmentation,
                                              conv_padding=conv_padding,
+                                             conv_upscale=conv_upscale,
                                              is3d=True)
 
 
@@ -158,7 +161,7 @@ class ResidualUNetSE3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, conv_upscale=2, **kwargs):
         super(ResidualUNetSE3D, self).__init__(in_channels=in_channels,
                                                out_channels=out_channels,
                                                final_sigmoid=final_sigmoid,
@@ -169,6 +172,7 @@ class ResidualUNetSE3D(AbstractUNet):
                                                num_levels=num_levels,
                                                is_segmentation=is_segmentation,
                                                conv_padding=conv_padding,
+                                               conv_upscale=conv_upscale,
                                                is3d=True)
 
 
@@ -179,7 +183,7 @@ class UNet2D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, conv_upscale=2, **kwargs):
         super(UNet2D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -190,6 +194,7 @@ class UNet2D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     conv_upscale=conv_upscale,
                                      is3d=False)
 
 

--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -32,7 +32,7 @@ class AbstractUNet(nn.Module):
         conv_kernel_size (int or tuple): size of the convolving kernel in the basic_module
         pool_kernel_size (int or tuple): the size of the window
         conv_padding (int or tuple): add zero-padding added to all three sides of the input
-        conv_upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
+        conv_upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
         is3d (bool): if True the model is 3D, otherwise 2D, default: True
     """
 
@@ -54,8 +54,8 @@ class AbstractUNet(nn.Module):
                                         layer_order, num_groups, pool_kernel_size, is3d)
 
         # create decoder path
-        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, conv_upscale,
-                                        layer_order, num_groups, is3d)
+        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups,
+                                        is3d)
 
         # in the last layer a 1×1 convolution reduces the number of output channels to the number of labels
         if is3d:

--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -32,7 +32,7 @@ class AbstractUNet(nn.Module):
         conv_kernel_size (int or tuple): size of the convolving kernel in the basic_module
         pool_kernel_size (int or tuple): the size of the window
         conv_padding (int or tuple): add zero-padding added to all three sides of the input
-        conv_upscale (int): number of the convolution to upscale in encoder if DoubleConv, default: 2
+        conv_upscale (int): number of the convolution to upscale in encoder/decoder if DoubleConv, default: 2
         is3d (bool): if True the model is 3D, otherwise 2D, default: True
     """
 
@@ -54,8 +54,8 @@ class AbstractUNet(nn.Module):
                                         layer_order, num_groups, pool_kernel_size, is3d)
 
         # create decoder path
-        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups,
-                                        is3d)
+        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, conv_upscale,
+                                        layer_order, num_groups, is3d)
 
         # in the last layer a 1×1 convolution reduces the number of output channels to the number of labels
         if is3d:


### PR DESCRIPTION
This PR introduces an optional `conv_upscale` parameter in the `AbstractUNet` and derived classes and use cases so that users can define at which level of the convolution (in case of DoubleConv) the upscaling should be performed. Default is set to 2 to ensure the same functionality like without the new `conv_upscale`