### PR TITLE
implement dynamic upsample mode flexibility

### DIFF
--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -322,7 +322,7 @@ class Decoder(nn.Module):
                     upsample = 'nearest'    # use nearest neighbot interpolation for upsampling
                     concat = True           # use concat joining
                     adapt_channels = False  # don't adapt channels
-                elif basic_module = ResNetBlock:
+                elif basic_module == ResNetBlock:
                     upsample = 'deconv'     # use deconvolution upsampling
                     concat = False          # use summation joining
                     adapt_channels = True   # adapt channels after joining
@@ -405,7 +405,7 @@ def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_
     decoders = []
     reversed_f_maps = list(reversed(f_maps))
     for i in range(len(reversed_f_maps) - 1):
-        if basic_module == DoubleConv:
+        if basic_module == DoubleConv and upsample is not 'deconv':
             in_feature_num = reversed_f_maps[i] + reversed_f_maps[i + 1]
         else:
             in_feature_num = reversed_f_maps[i]

--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -316,8 +316,8 @@ class Decoder(nn.Module):
         # don't adapt channels after join operation
         adapt_channels = False
 
-        if upsample is not None and upsample is not 'none':
-            if upsample is 'default':
+        if upsample is not None and upsample != 'none':
+            if upsample == 'default':
                 if basic_module == DoubleConv:
                     upsample = 'nearest'    # use nearest neighbot interpolation for upsampling
                     concat = True           # use concat joining
@@ -328,7 +328,7 @@ class Decoder(nn.Module):
                     adapt_channels = True   # adapt channels after joining
 
             # perform deconvolution upsampling if mode is deconv
-            if upsample is 'deconv':
+            if upsample == 'deconv':
                 self.upsampling = TransposeConvUpsampling(in_channels=in_channels, out_channels=out_channels,
                                                           kernel_size=conv_kernel_size, scale_factor=scale_factor,
                                                           is3d=is3d)
@@ -405,7 +405,7 @@ def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_
     decoders = []
     reversed_f_maps = list(reversed(f_maps))
     for i in range(len(reversed_f_maps) - 1):
-        if basic_module == DoubleConv and upsample is not 'deconv':
+        if basic_module == DoubleConv and upsample != 'deconv':
             in_feature_num = reversed_f_maps[i] + reversed_f_maps[i + 1]
         else:
             in_feature_num = reversed_f_maps[i]

--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -291,7 +291,7 @@ class Decoder(nn.Module):
         in_channels (int): number of input channels
         out_channels (int): number of output channels
         conv_kernel_size (int or tuple): size of the convolving kernel
-        scale_factor (tuple): used as the multiplier for the image H/W/D in
+        scale_factor (int or tuple): used as the multiplier for the image H/W/D in
             case of nn.Upsample or as stride in case of ConvTranspose3d, must reverse the MaxPool3d operation
             from the corresponding encoder
         basic_module(nn.Module): either ResNetBlock or DoubleConv
@@ -299,32 +299,53 @@ class Decoder(nn.Module):
             in `DoubleConv` module. See `DoubleConv` for more info.
         num_groups (int): number of groups for the GroupNorm
         padding (int or tuple): add zero-padding added to all three sides of the input
-        upsample (bool): should the input be upsampled
+        upsample (str): algorithm used for upsampling:
+            InterpolateUpsampling:   'nearest' | 'linear' | 'bilinear' | 'trilinear' | 'area'
+            TransposeConvUpsampling: 'deconv'
+            No upsampling:           None
+            Default: 'default' (chooses automatically)
     """
 
-    def __init__(self, in_channels, out_channels, conv_kernel_size=3, scale_factor=(2, 2, 2), basic_module=DoubleConv,
-                 conv_layer_order='gcr', num_groups=8, mode='nearest', padding=1, upsample=True, is3d=True):
+    def __init__(self, in_channels, out_channels, conv_kernel_size=3, scale_factor=2, basic_module=DoubleConv,
+                 conv_layer_order='gcr', num_groups=8, padding=1, upsample='default', is3d=True):
         super(Decoder, self).__init__()
+  
+        # perform concat joining per default
+        concat = True
 
-        if upsample:
-            if basic_module == DoubleConv:
-                # if DoubleConv is the basic_module use interpolation for upsampling and concatenation joining
-                self.upsampling = InterpolateUpsampling(mode=mode)
-                # concat joining
-                self.joining = partial(self._joining, concat=True)
-            else:
-                # if basic_module=ResNetBlock use transposed convolution upsampling and summation joining
+        # don't adapt channels after join operation
+        adapt_channels = False
+
+        if upsample is not None and upsample is not 'none':
+            if upsample is 'default':
+                if basic_module == DoubleConv:
+                    upsample = 'nearest'    # use nearest neighbot interpolation for upsampling
+                    concat = True           # use concat joining
+                    adapt_channels = False  # don't adapt channels
+                elif basic_module = ResNetBlock:
+                    upsample = 'deconv'     # use deconvolution upsampling
+                    concat = False          # use summation joining
+                    adapt_channels = True   # adapt channels after joining
+
+            # perform deconvolution upsampling if mode is deconv
+            if upsample is 'deconv':
                 self.upsampling = TransposeConvUpsampling(in_channels=in_channels, out_channels=out_channels,
-                                                          kernel_size=conv_kernel_size, scale_factor=scale_factor)
-                # sum joining
-                self.joining = partial(self._joining, concat=False)
-                # adapt the number of in_channels for the ResNetBlock
-                in_channels = out_channels
+                                                          kernel_size=conv_kernel_size, scale_factor=scale_factor,
+                                                          is3d=is3d)
+            else:
+                self.upsampling = InterpolateUpsampling(mode=upsample)
         else:
             # no upsampling
             self.upsampling = NoUpsampling()
             # concat joining
             self.joining = partial(self._joining, concat=True)
+
+        # perform joining operation
+        self.joining = partial(self._joining, concat=concat)
+
+        # adapt the number of in_channels for the ResNetBlock
+        if adapt_channels is True:
+            in_channels = out_channels
 
         self.basic_module = basic_module(in_channels, out_channels,
                                          encoder=False,
@@ -378,7 +399,8 @@ def create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_pa
     return nn.ModuleList(encoders)
 
 
-def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups, is3d):
+def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups, upsample,
+                    is3d):
     # create decoder path consisting of the Decoder modules. The length of the decoder list is equal to `len(f_maps) - 1`
     decoders = []
     reversed_f_maps = list(reversed(f_maps))
@@ -396,6 +418,7 @@ def create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_
                           conv_kernel_size=conv_kernel_size,
                           num_groups=num_groups,
                           padding=conv_padding,
+                          upsample=upsample,
                           is3d=is3d)
         decoders.append(decoder)
     return nn.ModuleList(decoders)
@@ -446,13 +469,17 @@ class TransposeConvUpsampling(AbstractUpsampling):
             used only if transposed_conv is True
         scale_factor (int or tuple): stride of the convolution
             used only if transposed_conv is True
-
+        is3d (bool): if True use ConvTranspose3d, otherwise use ConvTranspose2d
     """
 
-    def __init__(self, in_channels=None, out_channels=None, kernel_size=3, scale_factor=(2, 2, 2)):
+    def __init__(self, in_channels=None, out_channels=None, kernel_size=3, scale_factor=2, is3d=True):
         # make sure that the output size reverses the MaxPool3d from the corresponding encoder
-        upsample = nn.ConvTranspose3d(in_channels, out_channels, kernel_size=kernel_size, stride=scale_factor,
-                                      padding=1)
+        if is3d is True:
+          upsample = nn.ConvTranspose3d(in_channels, out_channels, kernel_size=kernel_size, stride=scale_factor,
+                                        padding=1, bias=False)
+        else:
+          upsample = nn.ConvTranspose2d(in_channels, out_channels, kernel_size=kernel_size, stride=scale_factor,
+                                        padding=1, bias=False)
         super().__init__(upsample)
 
 

--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -32,12 +32,17 @@ class AbstractUNet(nn.Module):
         conv_kernel_size (int or tuple): size of the convolving kernel in the basic_module
         pool_kernel_size (int or tuple): the size of the window
         conv_padding (int or tuple): add zero-padding added to all three sides of the input
+        upsample (str): algorithm used for decoder upsampling:
+            InterpolateUpsampling:   'nearest' | 'linear' | 'bilinear' | 'trilinear' | 'area'
+            TransposeConvUpsampling: 'deconv'
+            No upsampling:           None
+            Default: 'default' (chooses automatically)
         is3d (bool): if True the model is 3D, otherwise 2D, default: True
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid, basic_module, f_maps=64, layer_order='gcr',
                  num_groups=8, num_levels=4, is_segmentation=True, conv_kernel_size=3, pool_kernel_size=2,
-                 conv_padding=1, is3d=True):
+                 conv_padding=1, upsample='default', is3d=True):
         super(AbstractUNet, self).__init__()
 
         if isinstance(f_maps, int):
@@ -54,7 +59,7 @@ class AbstractUNet(nn.Module):
 
         # create decoder path
         self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups,
-                                        is3d)
+                                        upsample, is3d)
 
         # in the last layer a 1×1 convolution reduces the number of output channels to the number of labels
         if is3d:
@@ -110,7 +115,7 @@ class UNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, upsample='default', **kwargs):
         super(UNet3D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -121,6 +126,7 @@ class UNet3D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     upsample=upsample,
                                      is3d=True)
 
 
@@ -133,7 +139,7 @@ class ResidualUNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, upsample='default', **kwargs):
         super(ResidualUNet3D, self).__init__(in_channels=in_channels,
                                              out_channels=out_channels,
                                              final_sigmoid=final_sigmoid,
@@ -144,6 +150,7 @@ class ResidualUNet3D(AbstractUNet):
                                              num_levels=num_levels,
                                              is_segmentation=is_segmentation,
                                              conv_padding=conv_padding,
+                                             upsample=upsample,
                                              is3d=True)
 
 
@@ -158,7 +165,7 @@ class ResidualUNetSE3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, upsample='default', **kwargs):
         super(ResidualUNetSE3D, self).__init__(in_channels=in_channels,
                                                out_channels=out_channels,
                                                final_sigmoid=final_sigmoid,
@@ -169,6 +176,7 @@ class ResidualUNetSE3D(AbstractUNet):
                                                num_levels=num_levels,
                                                is_segmentation=is_segmentation,
                                                conv_padding=conv_padding,
+                                               upsample=upsample,
                                                is3d=True)
 
 
@@ -179,7 +187,7 @@ class UNet2D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, upsample='default', **kwargs):
         super(UNet2D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -190,6 +198,7 @@ class UNet2D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     upsample=upsample,
                                      is3d=False)
 
 


### PR DESCRIPTION
This PR changes the upsample procedure in the Decoder part of the UNet so that with a new optional `upsample` parameter a user can dynamically define if the corresponding upsampling in the decoder should be performed via a nearest neighbor (or other types) of interpolation or via a Deconvolution operation. For this purpose a new optional `upsample` parameter can be specified in the config yml which is set to `default` per default, so that the same automatic selection procedure is used as without this PR. However, if e.g. set to `deconv` a deconvolution operatin via `ConvTranspose3d` or `ConvTranspose2d` can be used for the upsampling operation. For this, the corresponding `TransposeConvUpsampling` class was changed to identify the 2d or 3d case, thus use a 2d or 3d convtranspose operation.