### PR TITLE
added final activation before eval score calculation

### DIFF
--- a/pytorch3dunet/unet3d/trainer.py
+++ b/pytorch3dunet/unet3d/trainer.py
@@ -209,7 +209,17 @@ class UNetTrainer:
             if self.num_iterations % self.log_after_iters == 0:
                 # compute eval criterion
                 if not self.skip_train_validation:
-                    eval_score = self.eval_criterion(output, target)
+                    # apply final activation before calculating eval score
+                    if isinstance(self.model, nn.DataParallel):
+                        final_activation = self.model.module.final_activation
+                    else:
+                        final_activation = self.model.final_activation
+
+                    if final_activation is not None:
+                        act_output = final_activation(output)
+                    else:
+                        act_output = output
+                    eval_score = self.eval_criterion(act_output, target)
                     train_eval_scores.update(eval_score.item(), self._batch_size(input))
 
                 # log stats, params and images


### PR DESCRIPTION
This PR applies the same final activation function before calculating the eval score than before calculating the validation score accordingly. This should make eval score calculation consistent with the validation score calculation (e.g. in case the Dice coefficient is used) so that both metrics are more comparable to each other.