### PR TITLE
fix NoneType situation if lr_scheduler is disabled.

### DIFF
--- a/pytorch3dunet/unet3d/trainer.py
+++ b/pytorch3dunet/unet3d/trainer.py
@@ -196,8 +196,9 @@ class UNetTrainer:
                 # adjust learning rate if necessary
                 if isinstance(self.scheduler, ReduceLROnPlateau):
                     self.scheduler.step(eval_score)
-                else:
+                elif self.scheduler is not None:
                     self.scheduler.step()
+
                 # log current learning rate in tensorboard
                 self._log_lr()
                 # remember best validation metric


### PR DESCRIPTION
This PR fixes a situation where in case the `lr_scheduler` is disabled in a yml config processing runs into a NoneType situation (crash). By adding a simply NoneType check this situation can be avoided however.