### PR TITLE
implemented dropout layer support for reducing overfitting.

### DIFF
--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -32,12 +32,13 @@ class AbstractUNet(nn.Module):
         conv_kernel_size (int or tuple): size of the convolving kernel in the basic_module
         pool_kernel_size (int or tuple): the size of the window
         conv_padding (int or tuple): add zero-padding added to all three sides of the input
+        dropout_prob (float or tuple): dropout probability, default: 0.1
         is3d (bool): if True the model is 3D, otherwise 2D, default: True
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid, basic_module, f_maps=64, layer_order='gcr',
                  num_groups=8, num_levels=4, is_segmentation=True, conv_kernel_size=3, pool_kernel_size=2,
-                 conv_padding=1, is3d=True):
+                 conv_padding=1, dropout_prob=0.1, is3d=True):
         super(AbstractUNet, self).__init__()
 
         if isinstance(f_maps, int):
@@ -49,11 +50,13 @@ class AbstractUNet(nn.Module):
             assert num_groups is not None, "num_groups must be specified if GroupNorm is used"
 
         # create encoder path
-        self.encoders = create_encoders(in_channels, f_maps, basic_module, conv_kernel_size, conv_padding, layer_order,
-                                        num_groups, pool_kernel_size, is3d)
+        self.encoders = create_encoders(in_channels, f_maps, basic_module, conv_kernel_size,
+                                        conv_padding, dropout_prob,
+                                        layer_order, num_groups, pool_kernel_size, is3d)
 
         # create decoder path
-        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding, layer_order, num_groups,
+        self.decoders = create_decoders(f_maps, basic_module, conv_kernel_size, conv_padding,
+                                        layer_order, num_groups, dropout_prob,
                                         is3d)
 
         # in the last layer a 1×1 convolution reduces the number of output channels to the number of labels
@@ -110,7 +113,8 @@ class UNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1,
+                 dropout_prob=0.1, **kwargs):
         super(UNet3D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -121,6 +125,7 @@ class UNet3D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     dropout_prob=dropout_prob,
                                      is3d=True)
 
 
@@ -133,7 +138,8 @@ class ResidualUNet3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1,
+                 dropout_prob=0.1, **kwargs):
         super(ResidualUNet3D, self).__init__(in_channels=in_channels,
                                              out_channels=out_channels,
                                              final_sigmoid=final_sigmoid,
@@ -144,6 +150,7 @@ class ResidualUNet3D(AbstractUNet):
                                              num_levels=num_levels,
                                              is_segmentation=is_segmentation,
                                              conv_padding=conv_padding,
+                                             dropout_prob=dropout_prob,
                                              is3d=True)
 
 
@@ -158,7 +165,8 @@ class ResidualUNetSE3D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1,
+                 dropout_prob=0.1, **kwargs):
         super(ResidualUNetSE3D, self).__init__(in_channels=in_channels,
                                                out_channels=out_channels,
                                                final_sigmoid=final_sigmoid,
@@ -169,6 +177,7 @@ class ResidualUNetSE3D(AbstractUNet):
                                                num_levels=num_levels,
                                                is_segmentation=is_segmentation,
                                                conv_padding=conv_padding,
+                                               dropout_prob=dropout_prob,
                                                is3d=True)
 
 
@@ -179,7 +188,8 @@ class UNet2D(AbstractUNet):
     """
 
     def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
-                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1, **kwargs):
+                 num_groups=8, num_levels=4, is_segmentation=True, conv_padding=1,
+                 dropout_prob=0.1, **kwargs):
         super(UNet2D, self).__init__(in_channels=in_channels,
                                      out_channels=out_channels,
                                      final_sigmoid=final_sigmoid,
@@ -190,6 +200,7 @@ class UNet2D(AbstractUNet):
                                      num_levels=num_levels,
                                      is_segmentation=is_segmentation,
                                      conv_padding=conv_padding,
+                                     dropout_prob=dropout_prob,
                                      is3d=False)
 
 


### PR DESCRIPTION
Now either a 'd' or 'D' can be specified in the model definition at 'layer_order' so that either nn.Dropout or spatial nn.Dropout2D layers can be added for potentially improved network regularization. In addition, the dropout probability can be specified by a new 'dropout_prob' parameter which can take a single float, a list or tuple of floats to allow to specify the dropout probability for each single convolution in the double convolution step.