### PR TITLE
Override config yaml with parameters from command line

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         conda install --yes -c conda-forge mamba
         mamba install -q boa
-        mamba mambabuild -c pytorch -c nvidia -c conda-forge conda-recipe
+        conda mambabuild -c pytorch -c nvidia -c conda-forge conda-recipe
     - name: Create pytorch3dunet env
       run: |
         mamba create -n pytorch3dunet -c pytorch -c nvidia -c conda-forge pytorch-3dunet pytest

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -12,6 +12,7 @@ logger = utils.get_logger('ConfigLoader')
 
 def _override_config(args, config):
     """Overrides config params with the ones given in command line."""
+
     args_dict = vars(args)
     # remove the first argument which is the config file path
     args_dict.pop('config')
@@ -33,6 +34,7 @@ def load_config():
     parser = argparse.ArgumentParser(description='UNet3D')
     parser.add_argument('--config', type=str, help='Path to the YAML config file', required=True)
     # add additional command line arguments for the prediction that override the ones in the config file
+    parser.add_argument('--model_path', type=str, required=False)
     parser.add_argument('--loaders.output_dir', type=str, nargs="+", required=False)
     parser.add_argument('--loaders.test.file_paths', type=str, required=False)
     parser.add_argument('--loaders.test.slice_builder.patch_shape', type=int, nargs="+", required=False)

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import shutil
+
 import torch
 import yaml
 
@@ -9,11 +10,37 @@ from pytorch3dunet.unet3d import utils
 logger = utils.get_logger('ConfigLoader')
 
 
+def _override_config(args, config):
+    """Overrides config params with the ones given in command line."""
+    args_dict = vars(args)
+    # remove the first argument which is the config file path
+    args_dict.pop('config')
+
+    for key, value in args_dict.items():
+        if value is None:
+            continue
+        c = config
+        for k in key.split('.'):
+            if k not in c:
+                raise ValueError(f'Invalid config key: {key}')
+            if isinstance(c[k], dict):
+                c = c[k]
+            else:
+                c[k] = value
+
+
 def load_config():
     parser = argparse.ArgumentParser(description='UNet3D')
     parser.add_argument('--config', type=str, help='Path to the YAML config file', required=True)
+    # add additional command line arguments for the prediction that override the ones in the config file
+    parser.add_argument('--loaders.output_dir', type=str, nargs="+", required=False)
+    parser.add_argument('--loaders.test.file_paths', type=str, required=False)
+    parser.add_argument('--loaders.test.slice_builder.patch_shape', type=int, nargs="+", required=False)
+    parser.add_argument('--loaders.test.slice_builder.stride_shape', type=int, nargs="+", required=False)
+
     args = parser.parse_args()
     config = yaml.safe_load(open(args.config, 'r'))
+    _override_config(args, config)
 
     device = config.get('device', None)
     if device == 'cpu':
@@ -31,16 +58,16 @@ def load_config():
 
 def copy_config(config, config_path):
     """Copies the config file to the checkpoint folder."""
-    
+
     def _get_last_subfolder_path(path):
         subfolders = [f.path for f in os.scandir(path) if f.is_dir()]
         return max(subfolders, default=None)
-    
+
     checkpoint_dir = os.path.join(
         config['trainer'].pop('checkpoint_dir'), 'logs')
     last_run_dir = _get_last_subfolder_path(checkpoint_dir)
     config_file_name = os.path.basename(config_path)
-    
+
     if last_run_dir:
         shutil.copy2(config_path, os.path.join(last_run_dir, config_file_name))
 


### PR DESCRIPTION
The following prediction time parameters can be overridden:
```
--model_path
--loaders.output_dir
--loaders.test.file_paths
--loaders.test.slice_builder.patch_shape
--loaders.test.slice_builder.stride_shape
```