### PR TITLE
Improve ResidualUNet

### DIFF
--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -218,6 +218,30 @@ class UNet2D(AbstractUNet):
                                      is3d=False)
 
 
+class ResidualUNet2D(AbstractUNet):
+    """
+    Residual 2DUnet model implementation based on https://arxiv.org/pdf/1706.00120.pdf.
+    """
+
+    def __init__(self, in_channels, out_channels, final_sigmoid=True, f_maps=64, layer_order='gcr',
+                 num_groups=8, num_levels=5, is_segmentation=True, conv_padding=1,
+                 conv_upscale=2, upsample='default', dropout_prob=0.1, **kwargs):
+        super(ResidualUNet2D, self).__init__(in_channels=in_channels,
+                                             out_channels=out_channels,
+                                             final_sigmoid=final_sigmoid,
+                                             basic_module=ResNetBlock,
+                                             f_maps=f_maps,
+                                             layer_order=layer_order,
+                                             num_groups=num_groups,
+                                             num_levels=num_levels,
+                                             is_segmentation=is_segmentation,
+                                             conv_padding=conv_padding,
+                                             conv_upscale=conv_upscale,
+                                             upsample=upsample,
+                                             dropout_prob=dropout_prob,
+                                             is3d=False)
+
+
 def get_model(model_config):
     model_class = get_class(model_config['name'], modules=[
         'pytorch3dunet.unet3d.model'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,14 @@
 import torch
 
 from pytorch3dunet.unet3d.buildingblocks import ResNetBlock
-from pytorch3dunet.unet3d.model import UNet2D, UNet3D, ResidualUNet3D, ResidualUNetSE3D
+from pytorch3dunet.unet3d.model import UNet2D, UNet3D, ResidualUNet3D, ResidualUNetSE3D, ResidualUNet2D
 
 
 class TestModel:
     def test_unet2d(self):
         model = UNet2D(1, 1, f_maps=16, final_sigmoid=True)
         model.eval()
-        x = torch.rand(1, 1, 64, 64)
+        x = torch.rand(1, 1, 65, 65)
         with torch.no_grad():
             y = model(x)
 
@@ -17,16 +17,16 @@ class TestModel:
     def test_unet3d(self):
         model = UNet3D(1, 1, f_maps=16, final_sigmoid=True)
         model.eval()
-        x = torch.rand(1, 1, 32, 64, 64)
+        x = torch.rand(1, 1, 33, 65, 65)
         with torch.no_grad():
             y = model(x)
 
         assert torch.all(0 <= y) and torch.all(y <= 1)
 
     def test_resnet_block1(self):
-        blk = ResNetBlock(32, 64, is3d=False, order='cgr')
+        blk = ResNetBlock(33, 64, is3d=False, order='cgr')
         blk.eval()
-        x = torch.rand(1, 32, 64, 64)
+        x = torch.rand(1, 33, 65, 65)
 
         with torch.no_grad():
             y = blk(x)
@@ -34,9 +34,9 @@ class TestModel:
         assert torch.all(0 <= y)
 
     def test_resnet_block2(self):
-        blk = ResNetBlock(32, 32, is3d=False, order='cgr')
+        blk = ResNetBlock(33, 32, is3d=False, order='cgr')
         blk.eval()
-        x = torch.rand(1, 32, 64, 64)
+        x = torch.rand(1, 33, 65, 65)
 
         with torch.no_grad():
             y = blk(x)
@@ -46,15 +46,24 @@ class TestModel:
     def test_resunet3d(self):
         model = ResidualUNet3D(1, 1, f_maps=16, final_sigmoid=True)
         model.eval()
-        x = torch.rand(1, 1, 32, 64, 64)
+        x = torch.rand(1, 1, 33, 65, 65)
         y = model(x)
+
+        assert torch.all(0 <= y) and torch.all(y <= 1)
+
+    def test_resunet2d(self):
+        model = ResidualUNet2D(1, 1, f_maps=16, final_sigmoid=True)
+        model.eval()
+        x = torch.rand(1, 1, 65, 65)
+        with torch.no_grad():
+            y = model(x)
 
         assert torch.all(0 <= y) and torch.all(y <= 1)
 
     def test_resunetSE3d(self):
         model = ResidualUNetSE3D(1, 1, f_maps=16, final_sigmoid=True)
         model.eval()
-        x = torch.rand(1, 1, 32, 64, 64)
+        x = torch.rand(1, 1, 33, 65, 65)
         y = model(x)
 
         assert torch.all(0 <= y) and torch.all(y <= 1)


### PR DESCRIPTION
Fix `ValueError: requested an output size...` in the `_output_padding` method in transposed convolution and allow arbitrary patch sizes to be passed to `ResidualUNet`.