### PR TITLE
Fix typo in loss_config key for BCEDiceLoss

### DIFF
--- a/pytorch3dunet/unet3d/losses.py
+++ b/pytorch3dunet/unet3d/losses.py
@@ -314,7 +314,7 @@ def _create_loss(name, loss_config, weight, ignore_index, pos_weight):
     if name == 'BCEWithLogitsLoss':
         return nn.BCEWithLogitsLoss(pos_weight=pos_weight)
     elif name == 'BCEDiceLoss':
-        alpha = loss_config.get('alphs', 1.)
+        alpha = loss_config.get('alpha', 1.)
         beta = loss_config.get('beta', 1.)
         return BCEDiceLoss(alpha, beta)
     elif name == 'CrossEntropyLoss':


### PR DESCRIPTION
This commit corrects a typo in the `_create_loss` function of `losses.py`. The key for fetching the `alpha` value in the `BCEDiceLoss` setup was incorrectly written as 'alphs'. It has been corrected to 'alpha'.