### PR TITLE
implemented channelwise support for Normalize transform.

### DIFF
--- a/pytorch3dunet/augment/transforms.py
+++ b/pytorch3dunet/augment/transforms.py
@@ -567,22 +567,22 @@ class Normalize:
             # get min/max channelwise
             axes = list(range(m.ndim))
             axes = tuple(axes[1:])
-            if self.min_value is None:
+            if self.min_value is None or 'None' in self.min_value:
                 min_value = np.min(m, axis=axes, keepdims=True)
 
-            if self.max_value is None:
+            if self.max_value is None or 'None' in self.max_value:
                 max_value = np.max(m, axis=axes, keepdims=True)
 
             # check if non None in self.min_value/self.max_value
             # if present and if so copy value to min_value
             if self.min_value is not None:
                 for i,v in enumerate(self.min_value):
-                    if v is not None:
+                    if v != 'None':
                         min_value[i] = v
 
             if self.max_value is not None:
                 for i,v in enumerate(self.max_value):
-                    if v is not None:
+                    if v != 'None':
                         max_value[i] = v
         else:
             if self.min_value is None:

--- a/pytorch3dunet/augment/transforms.py
+++ b/pytorch3dunet/augment/transforms.py
@@ -567,22 +567,22 @@ class Normalize:
             # get min/max channelwise
             axes = list(range(m.ndim))
             axes = tuple(axes[1:])
-            if self.min_value is None or 'None' in self.min_value:
+            if self.min_value is None:
                 min_value = np.min(m, axis=axes, keepdims=True)
 
-            if self.max_value is None or 'None' in self.max_value:
+            if self.max_value is None:
                 max_value = np.max(m, axis=axes, keepdims=True)
 
             # check if non None in self.min_value/self.max_value
             # if present and if so copy value to min_value
             if self.min_value is not None:
                 for i,v in enumerate(self.min_value):
-                    if v != 'None':
+                    if v is not None:
                         min_value[i] = v
 
             if self.max_value is not None:
                 for i,v in enumerate(self.max_value):
-                    if v != 'None':
+                    if v is not None:
                         max_value[i] = v
         else:
             if self.min_value is None:


### PR DESCRIPTION
This PR implements a multicalss/mzltichannel aware `Normalize` transform functionality where `channelwise: true` can be specified so that the Normalize transform is applied to each channel seperately. In addition, `min_value` and `max_value` also accept arrays now so that in addition data clipping can be performed accordingly. Thus, in an example yml file a `Normalize` transform step can now be specified as:

```yml
        - name: Normalize
          norm01: true
          channelwise: true
          min_value: [-150, None]
          max_value: [+150, None]
```

which will then applied a [0,1] Normalization for each channel seperately and with clipping between -150 and +150 applied to channel0 and no clipping applied to channel1.
