### PR TITLE
fix tracerwarning when trying to convert a model into torchscript

### DIFF
--- a/pytorch3dunet/unet3d/buildingblocks.py
+++ b/pytorch3dunet/unet3d/buildingblocks.py
@@ -522,13 +522,7 @@ class TransposeConvUpsampling(AbstractUpsampling):
 
         def forward(self, x, size):
             x = self.conv_transposed(x)
-            if self.is3d:
-                output_size = x.size()[-3:]
-            else:
-                output_size = x.size()[-2:]
-            if output_size != size:
-                return F.interpolate(x, size=size)
-            return x
+            return F.interpolate(x, size=size)
 
     def __init__(self, in_channels, out_channels, kernel_size=3, scale_factor=2, is3d=True):
         # make sure that the output size reverses the MaxPool3d from the corresponding encoder


### PR DESCRIPTION
This PR fixes a `TracerWarning` when trying to convert a trained model/checkpoint into a torchscript-based file by using the `torch.jit.trace()` method with example data and the model contains a `TransposeConvUpsampling` step. Now `F.interpolate()` is called without comparing output sizes because `F.interpolate()` will anyway not touch the tensor in case output size and input size matches. In addition, after having analyzed the processing time by executing `F.interpolate()` in case output size matches input size suggests that no interpolation takes place and that it should be neglectible to execute it at all times.

If not applied, the TracerWarning output by pytorch points at that very issue:

```
pytorch3dunet/unet3d/buildingblocks.py:529: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if output_size != size:
```