### PR TITLE
Fix GitHub Workflow: Conda Build

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set pytorch-3dunet version
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
     - name: Print pytorch-3dunet version
       run: echo $RELEASE_VERSION
     - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Before it doesn't allow branch name to include `/` and `-` such as `qy/fix-github-actions` because branch names are used as release version in workflow. Now I use a timestamp instead, which gives a special (and maybe meaningful) version number in GitHub workflow tests.