### PR TITLE
fix: remove redundant final_activation layer in model.py

### DIFF
--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -101,11 +101,6 @@ class AbstractUNet(nn.Module):
 
         x = self.final_conv(x)
 
-        # apply final_activation (i.e. Sigmoid or Softmax) only during prediction.
-        # During training the network outputs logits
-        if not self.training and self.final_activation is not None:
-            x = self.final_activation(x)
-
         return x
 
 


### PR DESCRIPTION
Remove redundant final_activation layer in the forward() method of AbstractUNet.

The layer is redundant because it is only applied during validation, however the loss function of segmentation models already applies a final activation layer. Therefore the final_activation layer is applied twice in these instances.