### PR TITLE
checkpoint_dir is a required argument

### DIFF
--- a/pytorch3dunet/unet3d/trainer.py
+++ b/pytorch3dunet/unet3d/trainer.py
@@ -142,7 +142,7 @@ class UNetTrainer:
         elif pre_trained is not None:
             logger.info(f"Logging pre-trained model from '{pre_trained}'...")
             utils.load_checkpoint(pre_trained, self.model, None)
-            if 'checkpoint_dir' not in kwargs:
+            if not self.checkpoint_dir:
                 self.checkpoint_dir = os.path.split(pre_trained)[0]
 
     def fit(self):


### PR DESCRIPTION
In the `__init__()` of class UNetTrainer, checkpoint_dir is out of kwargs.
https://github.com/wolny/pytorch-3dunet/blob/59170234fa902f946c7fa055e00396a054b6e9ca/pytorch3dunet/unet3d/trainer.py#L89-L92
The code always runs L145 if block; `if 'checkpoint_dir' not in kwargs:`.
https://github.com/wolny/pytorch-3dunet/blob/59170234fa902f946c7fa055e00396a054b6e9ca/pytorch3dunet/unet3d/trainer.py#L145-L146
It causes unintended overwrite of checkpoint file.
The if sentence should be `if not self.checkpoint_dir:` or the if block should be removed.