### PR TITLE
Use 'int64' instead of non-portable 'long'

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -17,16 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set pytorch-3dunet version
-      run: echo "RELEASE_VERSION=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
-    - name: Print pytorch-3dunet version
-      run: echo $RELEASE_VERSION
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-activate-base: true
         activate-environment: ""
         channels: local,conda-forge
         channel-priority: false
+        miniconda-version: "latest"
     - shell: bash -l {0}
       run: conda info --envs
     - name: Build pytorch-3dunet

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         auto-activate-base: true
         activate-environment: ""
-        channel-priority: strict
+        channel-priority: flexible
         miniforge-variant: Miniforge3
     - shell: bash -l {0}
       run: conda info --envs

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -9,7 +9,7 @@ on:
     branches: [master]
 
 jobs:
-  build-linux:
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -21,9 +21,8 @@ jobs:
       with:
         auto-activate-base: true
         activate-environment: ""
-        channels: local,conda-forge
-        channel-priority: false
-        miniconda-version: "latest"
+        channel-priority: strict
+        miniforge-variant: Miniforge3
     - shell: bash -l {0}
       run: conda info --envs
     - name: Build pytorch-3dunet
@@ -33,7 +32,7 @@ jobs:
         conda build -c pytorch -c nvidia -c conda-forge conda-recipe
     - name: Create pytorch3dunet env
       run: |
-        conda create -n pytorch3dunet -c pytorch -c nvidia -c conda-forge pytorch-3dunet pytest
+        conda create -n pytorch3dunet -c local -c pytorch -c nvidia -c conda-forge pytorch-3dunet pytest
     - name: Run pytest
       shell: bash -l {0}
       run: |

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -10,8 +10,11 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set pytorch-3dunet version
@@ -22,7 +25,7 @@ jobs:
       with:
         auto-activate-base: true
         activate-environment: ""
-        channels: local,conda-forge,defaults
+        channels: local,conda-forge
         channel-priority: false
     - shell: bash -l {0}
       run: conda info --envs
@@ -41,7 +44,7 @@ jobs:
         pytest
         conda deactivate
     - name: Deploy on conda
-      if: ${{ startsWith( github.ref, 'refs/tags/') && success() }}
+      if: ${{ matrix.os == 'ubuntu-latest' && startsWith( github.ref, 'refs/tags/') && success() }}
       env:
         ANACONDA_SECRET: ${{ secrets.ANACONDA_TOKEN }}
       shell: bash -l {0}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,8 @@
+{% set setup_py_data = load_setup_py_data() %}
+
 package:
   name: pytorch-3dunet
-  version: {{ RELEASE_VERSION }}
+  version: {{ setup_py_data['version'] }}
 
 source:
   path: ..

--- a/resources/3DUnet_multiclass/train_config.yaml
+++ b/resources/3DUnet_multiclass/train_config.yaml
@@ -129,7 +129,7 @@ loaders:
           # convert target volume to binary mask
         - name: ToTensor
           expand_dims: false
-          dtype: long
+          dtype: int64
 
   # configuration of the val loader
   val:
@@ -158,4 +158,4 @@ loaders:
       label:
         - name: ToTensor
           expand_dims: false
-          dtype: long
+          dtype: int64

--- a/tests/resources/config_train.yml
+++ b/tests/resources/config_train.yml
@@ -54,8 +54,8 @@ loaders:
         - name: ToTensor
           # do not expand dims for cross-entropy loss
           expand_dims: false
-          # cross-entropy loss requires target to be of type 'long'
-          dtype: 'long'
+          # cross-entropy loss requires target to be of type 'int64'
+          dtype: 'int64'
       weight:
         - name: ToTensor
           expand_dims: false
@@ -76,7 +76,7 @@ loaders:
       label:
         - name: ToTensor
           expand_dims: false
-          dtype: 'long'
+          dtype: 'int64'
       weight:
         - name: ToTensor
           expand_dims: false

--- a/tests/resources/config_train_2d.yml
+++ b/tests/resources/config_train_2d.yml
@@ -76,8 +76,8 @@ loaders:
         - name: ToTensor
           # do not expand dims for cross-entropy loss
           expand_dims: false
-          # cross-entropy loss requires target to be of type 'long'
-          dtype: 'long'
+          # cross-entropy loss requires target to be of type 'int64'
+          dtype: 'int64'
       weight:
         - name: ToTensor
           expand_dims: false
@@ -99,7 +99,7 @@ loaders:
       label:
         - name: ToTensor
           expand_dims: false
-          dtype: 'long'
+          dtype: 'int64'
       weight:
         - name: ToTensor
           expand_dims: false

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -5,7 +5,7 @@ from pytorch3dunet.augment.transforms import RandomLabelToAffinities, LabelToAff
 
 
 class TestTransforms:
-    config = {'dtype': 'long'}
+    config = {'dtype': 'int64'}
 
     def test_random_label_to_boundary(self):
         size = 20
@@ -62,7 +62,7 @@ class TestTransforms:
     def test_BaseTransformer(self):
         config = {
             'raw': [{'name': 'Standardize'}, {'name': 'ToTensor', 'expand_dims': True}],
-            'label': [{'name': 'ToTensor', 'expand_dims': False, 'dtype': 'long'}],
+            'label': [{'name': 'ToTensor', 'expand_dims': False, 'dtype': 'int64'}],
             'weight': [{'name': 'ToTensor', 'expand_dims': False}]
         }
         base_config = {'mean': 0, 'std': 1}
@@ -73,7 +73,7 @@ class TestTransforms:
         assert raw_transforms[1].expand_dims
         label_transforms = transformer.label_transform().transforms
         assert not label_transforms[0].expand_dims
-        assert label_transforms[0].dtype == 'long'
+        assert label_transforms[0].dtype == 'int64'
         weight_transforms = transformer.weight_transform().transforms
         assert not weight_transforms[0].expand_dims
 
@@ -89,7 +89,7 @@ class TestTransforms:
             'label': [
                 {'name': 'RandomFlip'},
                 {'name': 'RandomRotate90'},
-                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'long'}
+                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'int64'}
             ]
         }
         base_config = {'mean': 0, 'std': 1}
@@ -116,7 +116,7 @@ class TestTransforms:
                 {'name': 'RandomFlip'},
                 {'name': 'RandomRotate90'},
                 {'name': 'RandomRotate', 'angle_spectrum': 17, 'axes': [[2, 1]]},
-                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'long'}
+                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'int64'}
             ]
         }
         base_config = {'mean': 0, 'std': 1}
@@ -145,7 +145,7 @@ class TestTransforms:
                 {'name': 'RandomRotate90'},
                 {'name': 'RandomRotate', 'angle_spectrum': 17, 'axes': [[2, 1]], 'mode': 'reflect'},
                 {'name': 'LabelToAffinities', 'offsets': [2, 4, 6, 8]},
-                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'long'}
+                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'int64'}
             ]
         }
         base_config = {'mean': 0, 'std': 1}
@@ -179,7 +179,7 @@ class TestTransforms:
                 {'name': 'RandomRotate90'},
                 {'name': 'RandomRotate', 'angle_spectrum': 17, 'axes': [[2, 1]], 'mode': 'reflect'},
                 {'name': 'RandomLabelToAffinities', 'max_offset': 4},
-                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'long'}
+                {'name': 'ToTensor', 'expand_dims': False, 'dtype': 'int64'}
             ]
         }
         base_config = {'mean': 0, 'std': 1}


### PR DESCRIPTION
Unfortunately 'long' does not mean the same thing in different osses/compilers. On windows long will only be 32 bit (int32). Setting width explicitly is more portable.

The default dtype for in in numpy on windows is int32, but for pytorch int64... anyway. Cross-entropy loss will fail with 'long' on windows.

Bonus: Added CI to test win, macos ❤️ 