### PR TITLE
Add support for running on apple metal performance shader devices (apple silicon)

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -32,15 +32,6 @@ jobs:
       run: |
         conda install -q conda-build
         conda build -c conda-forge conda-recipe
-    - name: Create pytorch3dunet env
-      run: |
-        conda create -n pytorch3dunet -c local -c conda-forge pytorch-3dunet pytest
-    - name: Run pytest
-      shell: bash -l {0}
-      run: |
-        conda activate pytorch3dunet
-        pytest
-        conda deactivate
     - name: Deploy on conda
       if: ${{ matrix.os == 'ubuntu-latest' && startsWith( github.ref, 'refs/tags/') && success() }}
       env:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -16,12 +16,14 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
+        auto-update-conda: true
         auto-activate-base: true
         activate-environment: ""
-        channel-priority: flexible
+        channel-priority: strict
+        conda-remove-defaults: "true"
         miniforge-variant: Miniforge3
     - shell: bash -l {0}
       run: conda info --envs
@@ -29,10 +31,10 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install -q conda-build
-        conda build -c pytorch -c nvidia -c conda-forge conda-recipe
+        conda build -c conda-forge conda-recipe
     - name: Create pytorch3dunet env
       run: |
-        conda create -n pytorch3dunet -c local -c pytorch -c nvidia -c conda-forge pytorch-3dunet pytest
+        conda create -n pytorch3dunet -c local -c conda-forge pytorch-3dunet pytest
     - name: Run pytest
       shell: bash -l {0}
       run: |

--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ The format of the raw and label datasets depends on whether the problem is 2D or
 conda install -c conda-forge pytorch-3dunet
 ```
 
-To ensure that the GPU-ready version of PyTorch is installed:
-
-```
-conda install -c pytorch -c nvidia -c conda-forge pytorch pytorch-cuda=12.1 pytorch-3dunet
-```
-
 After installation the following commands will be accessible within the conda environment:
 `train3dunet` for training the network and `predict3dunet` for prediction (see below).
 

--- a/README.md
+++ b/README.md
@@ -287,4 +287,15 @@ publisher = {eLife Sciences Publications, Ltd},
 }
 ```
 
+## Development
 
+A development environment can be created via conda:
+
+```
+conda env create --file environment.yaml
+conda activate 3dunet
+pip install -e .
+```
+
+Tests can be run via `pytest`.
+The device the tests should be run on can be specified with the `--device` argument (`cpu`, `mps`, or `cuda` - default: `cpu`).

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
   source_files:
     - tests
   commands:
-    - pytest tests
+    - pytest -v
 
 about:
   home: https://github.com/wolny/pytorch-3dunet

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,11 +1,10 @@
 name: 3dunet
 
 channels:
-  - pytorch
   - conda-forge
 
 dependencies:
-  - python 3.9
+  - python 3.11
   - pytorch
   - tensorboard
   - tqdm

--- a/pytorch3dunet/datasets/utils.py
+++ b/pytorch3dunet/datasets/utils.py
@@ -383,12 +383,13 @@ def get_train_loaders(config: dict) -> dict[str, DataLoader]:
 
     logger.info(f'Batch size for train/val loader: {batch_size}')
     # when training with volumetric data use batch_size of 1 due to GPU memory constraints
+    os_depenent_kwargs = os_dependent_dataloader_kwargs()
     return {
-        'train': DataLoader(ConcatDataset(train_datasets), batch_size=batch_size, shuffle=True, pin_memory=True,
-                            num_workers=num_workers, drop_last=True),
+        'train': DataLoader(ConcatDataset(train_datasets), batch_size=batch_size, shuffle=True,
+                            num_workers=num_workers, drop_last=True, **os_depenent_kwargs),
         # don't shuffle during validation: useful when showing how predictions for a given batch get better over time
-        'val': DataLoader(ConcatDataset(val_datasets), batch_size=batch_size, shuffle=False, pin_memory=True,
-                          num_workers=num_workers, drop_last=True)
+        'val': DataLoader(ConcatDataset(val_datasets), batch_size=batch_size, shuffle=False,
+                          num_workers=num_workers, drop_last=True, **os_depenent_kwargs)
     }
 
 
@@ -434,8 +435,10 @@ def get_test_loaders(config: dict) -> DataLoader:
         else:
             collate_fn = default_prediction_collate
 
-        yield DataLoader(test_dataset, batch_size=batch_size, num_workers=num_workers, pin_memory=True,
-                         collate_fn=collate_fn)
+        os_depenent_kwargs = os_dependent_dataloader_kwargs()
+
+        yield DataLoader(
+            test_dataset, batch_size=batch_size, num_workers=num_workers, collate_fn=collate_fn, **os_depenent_kwargs)
 
 
 def default_prediction_collate(batch):

--- a/pytorch3dunet/datasets/utils.py
+++ b/pytorch3dunet/datasets/utils.py
@@ -2,6 +2,7 @@ import collections
 from typing import Any, Optional
 
 import numpy as np
+from pytorch3dunet.unet3d.config import TorchDevice, legacy_default_device, os_dependent_dataloader_kwargs
 import torch
 from torch.nn.functional import interpolate
 from torch.utils.data import DataLoader, ConcatDataset, Dataset
@@ -373,7 +374,8 @@ def get_train_loaders(config: dict) -> dict[str, DataLoader]:
     num_workers = loaders_config.get('num_workers', 1)
     logger.info(f'Number of workers for train/val dataloader: {num_workers}')
     batch_size = loaders_config.get('batch_size', 1)
-    if torch.cuda.device_count() > 1 and not config['device'] == 'cpu':
+    device = config["device"] if config["device"] is not None else legacy_default_device()
+    if device == TorchDevice.CUDA and torch.cuda.device_count() > 1:
         logger.info(
             f'{torch.cuda.device_count()} GPUs available. Using batch_size = {torch.cuda.device_count()} * {batch_size}'
         )
@@ -415,7 +417,8 @@ def get_test_loaders(config: dict) -> DataLoader:
     logger.info(f'Number of workers for the dataloader: {num_workers}')
 
     batch_size = loaders_config.get('batch_size', 1)
-    if torch.cuda.device_count() > 1 and not config['device'] == 'cpu':
+    device = config["device"] if config["device"] is not None else legacy_default_device()
+    if device == TorchDevice.CUDA and torch.cuda.device_count() > 1:
         logger.info(
             f'{torch.cuda.device_count()} GPUs available. Using batch_size = {torch.cuda.device_count()} * {batch_size}'
         )

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -1,13 +1,37 @@
 import argparse
 import os
 import shutil
+from enum import Enum
 
 import torch
 import yaml
 
 from pytorch3dunet.unet3d import utils
 
+
 logger = utils.get_logger('ConfigLoader')
+
+
+class TorchDevice(str, Enum):
+    CUDA = 'cuda'
+    MPS = 'mps'
+    CPU = "cpu"
+
+    @classmethod
+    def values(cls):
+        for x in map(lambda c: c.value, cls):
+            yield x
+
+
+def default_device() -> TorchDevice:
+    logger.info("No device specified in config - determining best device automatically")
+    device = TorchDevice.CPU
+    if torch.cuda.is_available():
+        device = TorchDevice.CUDA
+    elif torch.mps.is_available():
+        device = TorchDevice.MPS
+
+    return device
 
 
 def _override_config(args, config):
@@ -30,6 +54,7 @@ def _override_config(args, config):
                 c[k] = value
 
 
+
 def load_config():
     parser = argparse.ArgumentParser(description='UNet3D')
     parser.add_argument('--config', type=str, help='Path to the YAML config file', required=True)
@@ -45,17 +70,16 @@ def load_config():
     config = yaml.safe_load(open(config_path, 'r'))
     _override_config(args, config)
 
-    device = config.get('device', None)
-    if device == 'cpu':
-        logger.warning('CPU mode forced in config, this will likely result in slow training/prediction')
-        config['device'] = 'cpu'
-        return config, config_path
+    config_device = config.get('device', None)
 
-    if torch.cuda.is_available():
-        config['device'] = 'cuda'
-    else:
-        logger.warning('CUDA not available, using CPU')
-        config['device'] = 'cpu'
+    try:
+        config['device'] = TorchDevice(config_device) if config_device is not None else default_device()
+    except ValueError as e:
+        raise ValueError(f"Config key device: {config_device} not understood -- supported values: {', '.join(TorchDevice.values())}") from e
+
+    if config['device'] == TorchDevice.CPU:
+        logger.warning('CPU mode will likely result in slow training/prediction')
+
     return config, config_path
 
 

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -88,7 +88,7 @@ def load_config():
 
     args = parser.parse_args()
     config_path = args.config
-    config = yaml.safe_load(open(config_path, 'r'))
+    config = _load_config_yaml(config_path)
     _override_config(args, config)
 
     config_device = config.get('device', None)
@@ -121,4 +121,5 @@ def copy_config(config, config_path):
 
 
 def _load_config_yaml(config_file):
-    return yaml.safe_load(open(config_file, 'r'))
+    with open(config_file, "r") as f:
+        return yaml.safe_load(f)

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -23,6 +23,17 @@ class TorchDevice(str, Enum):
             yield x
 
 
+def legacy_default_device() -> TorchDevice:
+    """Emulate legacy implementation where cuda was used if available
+
+    which was to use CUDA for certain things if available.
+    """
+    if torch.cuda.is_available():
+        return TorchDevice.CUDA
+
+    return TorchDevice.CPU
+
+
 def default_device() -> TorchDevice:
     logger.info("No device specified in config - determining best device automatically")
     device = TorchDevice.CPU

--- a/pytorch3dunet/unet3d/config.py
+++ b/pytorch3dunet/unet3d/config.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import platform
 import shutil
 from enum import Enum
 
@@ -43,6 +44,15 @@ def default_device() -> TorchDevice:
         device = TorchDevice.MPS
 
     return device
+
+
+def os_dependent_dataloader_kwargs() -> dict:
+    kwargs = dict(pin_memory=True)
+    if platform.system() == "Darwin":
+        # Considerable performance improvement avoiding spawn for dataloaders and persisting loaders on MacOSX
+        kwargs = dict(multiprocessing_context="forkserver", persistent_workers=True)
+
+    return kwargs
 
 
 def _override_config(args, config):

--- a/pytorch3dunet/unet3d/losses.py
+++ b/pytorch3dunet/unet3d/losses.py
@@ -4,6 +4,7 @@ from torch import nn as nn
 from torch.nn import MSELoss, SmoothL1Loss, L1Loss
 
 from pytorch3dunet.unet3d.utils import get_logger
+from pytorch3dunet.unet3d.config import TorchDevice, legacy_default_device
 
 logger = get_logger('Loss')
 
@@ -244,6 +245,13 @@ def get_loss_criterion(config):
     :return: an instance of the loss function
     """
     assert 'loss' in config, 'Could not find loss function configuration'
+
+    if "device" not in config:
+        logger.warning("No device specified in config - legacy mode will try to choose a sensible device")
+        device = legacy_default_device()
+    else:
+        device: TorchDevice = config["device"]
+
     loss_config = config['loss']
     name = loss_config.pop('name')
     logger.info(f"Creating loss function: {name}")
@@ -269,8 +277,7 @@ def get_loss_criterion(config):
     if skip_last_target:
         loss = SkipLastTargetChannelWrapper(loss, loss_config.get('squeeze_channel', False))
 
-    if torch.cuda.is_available():
-        loss = loss.cuda()
+    loss.to(device)
 
     return loss
 

--- a/pytorch3dunet/unet3d/predictor.py
+++ b/pytorch3dunet/unet3d/predictor.py
@@ -21,7 +21,7 @@ from pytorch3dunet.unet3d.utils import get_logger
 logger = get_logger('UNetPredictor')
 
 
-def _get_output_file(dataset: AbstractHDF5Dataset, suffix: str = '_predictions', output_dir: str = None) -> Path:
+def _get_output_file(dataset: AbstractHDF5Dataset, suffix: str = '_predictions', output_dir: Optional[Union[str, Path]] = None) -> Path:
     """
     Get the output file path for the predictions. If `output_dir` is not None the output file will be saved in
     the original dataset directory.
@@ -43,7 +43,7 @@ def _get_output_file(dataset: AbstractHDF5Dataset, suffix: str = '_predictions',
         output_dir = Path(output_dir)
 
     output_filename = file_path.stem + suffix + '.h5'
-    return Path(output_dir) / output_filename
+    return output_dir / output_filename
 
 
 def _load_dataset(dataset: AbstractHDF5Dataset, internal_path: str) -> np.ndarray:
@@ -109,9 +109,9 @@ class _AbstractPredictor:
                  out_channels: int,
                  output_dataset: str = 'predictions',
                  save_segmentation: bool = False,
-                 prediction_channel: int = None,
-                 performance_metric: str = None,
-                 gt_internal_path: str = None,
+                 prediction_channel: Optional[int] = None,
+                 performance_metric: Optional[str] = None,
+                 gt_internal_path: Optional[str] = None,
                  device: Optional[TorchDevice] = None,
                  **kwargs):
         """
@@ -160,9 +160,9 @@ class StandardPredictor(_AbstractPredictor):
                  out_channels: int,
                  output_dataset: str = 'predictions',
                  save_segmentation: bool = False,
-                 prediction_channel: int = None,
-                 performance_metric: str = None,
-                 gt_internal_path: str = None,
+                 prediction_channel: Optional[int] = None,
+                 performance_metric: Optional[str] = None,
+                 gt_internal_path: Optional[str] = None,
                  device: Optional[TorchDevice] = None,
                  **kwargs):
         super().__init__(model, output_dir, out_channels, output_dataset, save_segmentation, prediction_channel,
@@ -296,9 +296,9 @@ class LazyPredictor(StandardPredictor):
                  out_channels: int,
                  output_dataset: str = 'predictions',
                  save_segmentation: bool = False,
-                 prediction_channel: int = None,
-                 performance_metric: str = None,
-                 gt_internal_path: str = None,
+                 prediction_channel: Optional[int] = None,
+                 performance_metric: Optional[str] = None,
+                 gt_internal_path: Optional[str] = None,
                  device: Optional[TorchDevice] = None,
                  **kwargs):
         super().__init__(model, output_dir, out_channels, output_dataset, save_segmentation, prediction_channel,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,20 @@ import numpy as np
 import pytest
 import yaml
 
+from pytorch3dunet.unet3d.config import TorchDevice
+
 TEST_FILES = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     'resources',
 )
+
+def pytest_addoption(parser):
+    parser.addoption("--device", type=TorchDevice, help="torch device to run on (cpu, cuda, mps)", default="cpu")
+
+
+@pytest.fixture
+def device(request):
+    return request.config.getoption("--device")
 
 
 @pytest.fixture
@@ -19,33 +29,43 @@ def ovule_label():
 
 
 @pytest.fixture
-def transformer_config():
+def transformer_config(device):
     config_path = os.path.join(TEST_FILES, 'transformer_config.yml')
-    return yaml.safe_load(open(config_path, 'r'))
+    config = yaml.safe_load(open(config_path, 'r'))
+    config['device'] = device
+    return config
 
 
 @pytest.fixture
-def train_config():
+def train_config(device):
     config_path = os.path.join(TEST_FILES, 'config_train.yml')
-    return yaml.safe_load(open(config_path, 'r'))
+    config = yaml.safe_load(open(config_path, 'r'))
+    config['device'] = device
+    return config
 
 
 @pytest.fixture
-def test_config():
+def test_config(device):
     config_path = os.path.join(TEST_FILES, 'config_test.yml')
-    return yaml.safe_load(open(config_path, 'r'))
+    config = yaml.safe_load(open(config_path, 'r'))
+    config['device'] = device
+    return config
 
 
 @pytest.fixture
-def test_config_2d():
+def test_config_2d(device):
     config_path = os.path.join(TEST_FILES, 'config_test_2d.yml')
-    return yaml.safe_load(open(config_path, 'r'))
+    config = yaml.safe_load(open(config_path, 'r'))
+    config['device'] = device
+    return config
 
 
 @pytest.fixture
-def train_config_2d():
+def train_config_2d(device):
     config_path = os.path.join(TEST_FILES, 'config_train_2d.yml')
-    return yaml.safe_load(open(config_path, 'r'))
+    config = yaml.safe_load(open(config_path, 'r'))
+    config['device'] = device
+    return config
 
 
 @pytest.fixture

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -23,8 +23,8 @@ def _run_prediction(test_config, tmpdir, shape):
     test_config['loaders']['test']['file_paths'] = [tmp.name]
     # Create the model with random weights
     model = get_model(test_config['model'])
-    if torch.cuda.is_available():
-        model.cuda()
+
+    model = model.to(test_config["device"])
     results = []
     for test_loader in get_test_loaders(test_config):
         predictor = get_predictor(model, test_config)


### PR DESCRIPTION
This PR enables running 2D prediction/training on apple silicon devices.

I tried to keep everything backwards compatible. Only the tests now have a slightly different behavior: per default they run on cpu. Device can be specified via `pytest --device=cuda` for example.

The code had many locations checking independently whether a cuda device is present or not. I don't think it would've been possible to enforce cpu execution before as the config value was only checked in some places. The behavior is now more unified.

Summary:
* enables running inference and training on apple silicon. Note: 3D networks are not supported (by pytorch on mps) yet.
* updated the environment and installation instructions to reflect that conda channels "pytorch" and "nvidia" are not maintained anymore. Pytorch versions on "conda-forge" work well, and in most cases no convincing needs to be done anymore to get a version that runs on a gpu.
* testing: device to run tests on is now set explicitly via `--device` command line flag. Note: 3D ops are not well supported via pytorch on mps - so some tests will fail for that reason. 2D networks seem to run fine.


Tiny benchmark on my MBP with Apple Silicon M1 - training DSP for 3 epochs:

* old/cpu: 10:30 min for 3 epochs (48it)
* new/mps: 0:31 min for 3 epochs (48it)

So roughly a 20x speed gain running on mps.
