### PR TITLE
Allow baseclass to be configured from child instance

### DIFF
--- a/pytorch3dunet/unet3d/model.py
+++ b/pytorch3dunet/unet3d/model.py
@@ -155,7 +155,9 @@ class UNet3D(AbstractUNet):
                                      conv_upscale=conv_upscale,
                                      upsample=upsample,
                                      dropout_prob=dropout_prob,
-                                     is3d=True)
+                                     is3d=True,
+                                     **kwargs)
+        self.num_classes = out_channels
 
 
 class ResidualUNet3D(AbstractUNet):
@@ -182,7 +184,8 @@ class ResidualUNet3D(AbstractUNet):
                                              conv_upscale=conv_upscale,
                                              upsample=upsample,
                                              dropout_prob=dropout_prob,
-                                             is3d=True)
+                                             is3d=True,
+                                            **kwargs)
 
 
 class ResidualUNetSE3D(AbstractUNet):
@@ -211,7 +214,8 @@ class ResidualUNetSE3D(AbstractUNet):
                                                conv_upscale=conv_upscale,
                                                upsample=upsample,
                                                dropout_prob=dropout_prob,
-                                               is3d=True)
+                                               is3d=True,
+                                               **kwargs)
 
 
 class UNet2D(AbstractUNet):
@@ -236,7 +240,8 @@ class UNet2D(AbstractUNet):
                                      conv_upscale=conv_upscale,
                                      upsample=upsample,
                                      dropout_prob=dropout_prob,
-                                     is3d=False)
+                                     is3d=False,
+                                     **kwargs)
 
 
 class ResidualUNet2D(AbstractUNet):
@@ -260,7 +265,8 @@ class ResidualUNet2D(AbstractUNet):
                                              conv_upscale=conv_upscale,
                                              upsample=upsample,
                                              dropout_prob=dropout_prob,
-                                             is3d=False)
+                                             is3d=False,
+                                             **kwargs)
 
 
 def get_model(model_config):


### PR DESCRIPTION
Added `**kwargs` as argument to `__init__()` methods for classes which inherit from `AbstractUNet`. This allows models to be configured more closely at instantiation, e.g. changing the convolution or pooling kernel shapes. 