### PR TITLE
Pin networkx lib to fix naming conflicts on Windows

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - scikit-image
     - pyyaml
     - pip
+    - "networkx <3.0"
 
 test:
   imports:

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,3 +19,4 @@ dependencies:
   - pip:
     - torch
     - torchvision
+    - "networkx<3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "h5py",
     "scipy",
     "scikit-image",
-    "pyyaml"
+    "pyyaml",
+    "networkx<3.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
The issue is that networkx is being imported as a dependency of PyTorch's internal modules, but it's creating invalid Python identifiers. The solution is to pin networkx to a version that doesn't have this issue.