### PR TITLE
fix resume from checkpoint when using multiple GPUs

### DIFF
--- a/pytorch3dunet/unet3d/trainer.py
+++ b/pytorch3dunet/unet3d/trainer.py
@@ -204,7 +204,6 @@ class UNetTrainer:
             self.model = nn.DataParallel(self.model)
             logger.info(f"Using {torch.cuda.device_count()} GPUs for training")
 
-
     def fit(self):
         for _ in range(self.num_epochs, self.max_num_epochs):
             # train for one epoch

--- a/pytorch3dunet/unet3d/trainer.py
+++ b/pytorch3dunet/unet3d/trainer.py
@@ -36,11 +36,6 @@ def create_trainer(config: dict) -> "UNetTrainer":
     device = config.get("device", None)
     assert device, "Device not specified in the config file and could not be inferred automatically"
     logger.info(f"Using device: {device}")
-
-    # use DataParallel if more than 1 GPU available
-    if device == TorchDevice.CUDA and torch.cuda.device_count() > 1:
-        model = nn.DataParallel(model)
-        logger.info(f"Using {torch.cuda.device_count()} GPUs for training")
     model.to(device)
 
     # Log the number of learnable parameters
@@ -203,6 +198,12 @@ class UNetTrainer:
             load_checkpoint(pre_trained, self.model, None)
             if not self.checkpoint_dir:
                 self.checkpoint_dir = os.path.split(pre_trained)[0]
+
+        # use DataParallel if more than 1 GPU available
+        if device == TorchDevice.CUDA and torch.cuda.device_count() > 1:
+            self.model = nn.DataParallel(self.model)
+            logger.info(f"Using {torch.cuda.device_count()} GPUs for training")
+
 
     def fit(self):
         for _ in range(self.num_epochs, self.max_num_epochs):


### PR DESCRIPTION
### Summary
This PR fixes an issue where models are wrapped in 'nn.DataParallel' before checkpoint loading, causing state_dict key mismatches when resuming training or loading pre-trained weights.

### Example Error
Missing key(s) in state_dict "module.encoders.0.basic_module.SingleConv1.conv.weight"
Unexpected key(s) in state_dict "encoders.0.basic_module.SingleConv1.conv.weight"

### Root Cause
Checkpoints are saved without the 'module.' prefix, but the model is wrapped with 'DataParallel' before calling 'load_state_dict'.

### Fix
Ensure checkpoints are loaded into the underlying model before wrapping with 'DataParallel'

### Impact
Fixes resume/pre-trained loading when running parallel / multi-GPU training. No change to single-GPU or fresh training behavior.